### PR TITLE
Potential fix for code scanning alert no. 3: Clear text storage of sensitive information

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
-    "yup": "^1.7.0"
+    "yup": "^1.7.0",
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
Potential fix for [https://github.com/himanshubokde21/Remind-Candles/security/code-scanning/3](https://github.com/himanshubokde21/Remind-Candles/security/code-scanning/3)

The best way to fix the problem is to encrypt the wishes before storage and decrypt them after retrieval from localStorage. For this example, a lightweight symmetric encryption using the CryptoJS library is a pragmatic approach in a browser environment. Specifically:

1. Encrypt the result of `JSON.stringify(this.wishes)` before saving to localStorage in `saveWishes()`, and decrypt the value loaded from localStorage in `loadWishes()` before parsing.
2. Add a symmetric key (hardcoded, or preferably sourced securely) for encryption/decryption.
3. Add CryptoJS as a dependency and import the required functions.
4. Change ONLY `src/services/WishLibraryService.ts` per the code snippets provided.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
